### PR TITLE
Always be online if the browser does not support online/offline status

### DIFF
--- a/src/useOnlineState.js
+++ b/src/useOnlineState.js
@@ -6,10 +6,17 @@ import useGlobalEvent from './useGlobalEvent';
  * whether the browser is connected or not.
  */
 const useOnlineState = () => {
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  // If the browser doesn't support `navigator.onLine`, it will always come out as false/undefined. And IE8 only
+  // supports the online/offline events on document.body, rather than window. So we can properly detect if this hook
+  // works fine with online/offline status on browsers by checking existence of `window.ononline`.
+  const isSupported = 'ononline' in window;
+  const [isOnline, setIsOnline] = useState(isSupported ? navigator.onLine : true);
   const whenOnline = useGlobalEvent('online', { capture: true });
   const whenOffline = useGlobalEvent('offline', { capture: true });
 
+  if (!isSupported) {
+    console.log('Please note: your device does not support the \'online\' event, you should avoid using useOnlineState');
+  }
 
   whenOnline(() => {
     setIsOnline(true);

--- a/src/useOnlineState.js
+++ b/src/useOnlineState.js
@@ -15,7 +15,8 @@ const useOnlineState = () => {
   const whenOffline = useGlobalEvent('offline', { capture: true });
 
   if (!isSupported) {
-    console.log('Please note: your device does not support the \'online\' event, you should avoid using useOnlineState');
+    // eslint-disable-next-line no-console
+    console.warn('Your device does not support the \'online\' event, you should avoid using useOnlineState');
   }
 
   whenOnline(() => {

--- a/src/useOnlineState.spec.js
+++ b/src/useOnlineState.spec.js
@@ -1,8 +1,12 @@
+import { fireEvent } from '@testing-library/react';
 import { renderHook, cleanup } from '@testing-library/react-hooks';
 import useOnlineState from './useOnlineState';
 
 describe('useOnlineState', () => {
-  beforeEach(cleanup);
+  beforeEach(() => {
+    cleanup();
+    window.ononline = null;
+  });
 
   it('should be an arrow function', () => {
     expect(useOnlineState).to.be.a('function');
@@ -13,5 +17,29 @@ describe('useOnlineState', () => {
     const { result } = renderHook(() => useOnlineState('resize'));
 
     expect(result.current).to.be.a('boolean');
+  });
+
+  it('should return true if the device not support online event', () => {
+    delete window.ononline;
+
+    const spy = sinon.spy(window.console, 'warn');
+    const { result } = renderHook(() => useOnlineState());
+    expect(spy.calledOnce).to.be.true;
+    expect(result.current).to.be.true;
+  });
+
+  it('should change after an online/offline event', () => {
+    const { result } = renderHook(() => useOnlineState());
+    expect(result.current).to.be.true;
+
+    const offlineEvent = window.document.createEvent('Event');
+    offlineEvent.initEvent('offline', false, false);
+    fireEvent(window, offlineEvent);
+    expect(result.current).to.be.false;
+
+    const onlineEvent = window.document.createEvent('Event');
+    onlineEvent.initEvent('online', false, false);
+    fireEvent(window, onlineEvent);
+    expect(result.current).to.be.true;
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In general cases, someone who going to use an online hook, is more likely wanna know when does his user's network status be switched to offline, so he can deliver a notice or different content to his users. So it is default to be online.
