### PR TITLE
:bug: :memo: Update cancelable typings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,3 +324,9 @@ online
 ### Fixed
 
 - adding types for useConditionalTimeout
+
+## [0.19.2] - 2020-01-22
+
+### Fixed
+
+- Updated typings for cancelable functions. Updated docs.

--- a/docs/useDebouncedFn.md
+++ b/docs/useDebouncedFn.md
@@ -14,7 +14,7 @@ is performing
 ## Basic Usage
 
 ```jsx harmony
-import { useState } from 'react'; 
+import { useEffect, useState } from 'react'; 
 import { useWindowResize, useDebouncedFn } from 'beautiful-react-hooks'; 
 
 const DebouncedFnComponent = () => {
@@ -29,6 +29,11 @@ const DebouncedFnComponent = () => {
    }, 250);
    
    useWindowResize(onWindowResizeHandler);
+   useEffect(() => {
+     // do something
+     // don't forget to cancel debounced
+     return () => onWindowResizeHandler.cancel(); // or .flush()
+   });
       
    return (
      <DisplayDemo>

--- a/docs/useThrottledFn.md
+++ b/docs/useThrottledFn.md
@@ -13,7 +13,7 @@ is performing
 ## Basic Usage
 
 ```jsx harmony
-import { useState } from 'react'; 
+import { useEffect, useState } from 'react'; 
 import { useWindowResize, useThrottledFn } from 'beautiful-react-hooks'; 
 
 const ThrottledFnComponent = () => {
@@ -28,6 +28,11 @@ const ThrottledFnComponent = () => {
    }, 250);
    
    useWindowResize(onWindowResizeHandler);
+   useEffect(() => {
+     // do something
+     // don't forget to cancel debounced
+     return () => onWindowResizeHandler.cancel(); // or .flush()
+   });
       
    return (
      <DisplayDemo>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject, EffectCallback, DependencyList } from 'react';
+import { Cancelable } from 'lodash';
 
 type ThrottleOrDebounceOpts = {
   leading: boolean,
@@ -20,7 +21,7 @@ type HandlerSetter = (...parameters: Array<any>) => unknown;
 /**
  * useDebouncedFn
  */
-export declare const useDebouncedFn: (fn: Function, wait?: number, options?: ThrottleOrDebounceOpts, dependencies?: DependencyList) => EffectCallback;
+export declare const useDebouncedFn: (fn: Function, wait?: number, options?: ThrottleOrDebounceOpts, dependencies?: DependencyList) => Cancelable;
 
 /**
  * useDidMount
@@ -160,7 +161,7 @@ export declare const usePreviousValue: (value: any) => any;
 /**
  * useThrottledFn
  */
-export declare const useThrottledFn: (fn: Function, wait?: number, options?: ThrottleOrDebounceOpts, dependencies?: DependencyList) => EffectCallback;
+export declare const useThrottledFn: (fn: Function, wait?: number, options?: ThrottleOrDebounceOpts, dependencies?: DependencyList) => Cancelable;
 
 /**
  * useTimeout

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import { MutableRefObject, EffectCallback, DependencyList } from 'react';
-import { Cancelable } from 'lodash';
 
 type ThrottleOrDebounceOpts = {
   leading: boolean,
@@ -17,6 +16,11 @@ type EventListenerOptions = {
 }
 
 type HandlerSetter = (...parameters: Array<any>) => unknown;
+
+type Cancelable = {
+  cancel(): void;
+  flush(): void;
+}
 
 /**
  * useDebouncedFn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Updated `useThrottledFn` and `useDebouncedFn` declarations.
Updated documentation for them.

## Related Issue
IDE doesn't show that `useDebouncedFn` or `useThrottledFn` returns `Cancelable` object.
Now we know it and we can use `.cancel()` or `.flush()` methods for cleaning timers.

## Motivation and Context
Make react hooks better, control performance.
