### PR TITLE
:bug: Fix isSupported when window is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,3 +364,9 @@ online
 ### Added
 
 - useRequestAnimationFrame hook & tests
+
+## [0.21.1] - 2020-02-20
+
+### Fixed
+
+- Fix isSupported when window is not defined to allow SSR

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "dist/index.js",
   "scripts": {

--- a/src/useGeolocationEvents.js
+++ b/src/useGeolocationEvents.js
@@ -13,7 +13,7 @@ const useGeolocationEvents = (options = geolocationStandardOptions) => {
   const watchId = useRef();
   const [onChangeRef, setOnChangeRef] = createHandlerSetter();
   const [onErrorRef, setOnErrorRef] = createHandlerSetter();
-  const isSupported = 'geolocation' in window.navigator; // fixme: shall this be moved outside the hook?
+  const isSupported = typeof window !== 'undefined' && 'geolocation' in window.navigator;
 
   useEffect(() => {
     const onSuccess = (successEvent) => {

--- a/src/useMediaQuery.js
+++ b/src/useMediaQuery.js
@@ -10,7 +10,9 @@ import createCbSetterErrorProxy from './utils/createCbSetterErrorProxy';
  *
  */
 const useMediaQuery = (mediaQuery) => {
-  if (!('matchMedia' in window)) return createCbSetterErrorProxy('matchMedia is not supported');
+  if (typeof window === 'undefined' || !('matchMedia' in window)) {
+    return createCbSetterErrorProxy('matchMedia is not supported');
+  }
 
   const [isVerified, setIsVerified] = useState(!!window.matchMedia(mediaQuery).matches);
 

--- a/src/useOnlineState.js
+++ b/src/useOnlineState.js
@@ -10,7 +10,7 @@ const useOnlineState = () => {
    * If the browser doesn't support the `navigator.onLine` state, the hook will always return true
    * assuming the app is already online.
    */
-  const isSupported = 'ononline' in window;
+  const isSupported = typeof window !== 'undefined' && 'ononline' in window;
   const [isOnline, setIsOnline] = useState(isSupported ? navigator.onLine : true);
   const whenOnline = useGlobalEvent('online', { capture: true });
   const whenOffline = useGlobalEvent('offline', { capture: true });


### PR DESCRIPTION
## Description
Add `typeof window !== 'undefined'` checks to `isSupported`

- Removed a "fixme" `shall this be moved outside the hook?` <- no I guess it shouldn't!

## Related Issue
#63 

## Motivation and Context
Solves an issue where using hooks that use `window` fail SSR builds.

## How Has This Been Tested?
Couldn't add unit tests for this.