### PR TITLE
Fix useLocalStorage hook with SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,3 +469,11 @@ online
 ### Added
 
 - useStorage hook & tests
+
+## [0.24.1] - 2020-03-26
+
+### Fixed
+
+- adding SSR warning to `useLocalStorage` hook
+- adding warning to `useLocalStorage` hook if `localStorage` is not in `window` object
+- adding new test for `useLocalStorage` hook that checks that `localStorage` in `window` object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beautiful-react-hooks",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "A collection of beautiful (and hopefully useful) React hooks to speed-up your components and hooks development",
   "main": "dist/index.js",
   "scripts": {

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -1,10 +1,21 @@
 import { useState, useEffect } from 'react';
 import safelyParseJson from './utils/safelyParseJson';
+import isClient from './utils/isClient';
+import isAPISupported from './utils/isAPISupported';
+
+const errorMessage = 'localStorage is not supported, this could happen both because window.localStorage is not '
+    + 'supported by your current browser or you\'re using the useLocalStorage hook whilst server side rendering.';
 
 /**
  * Save a value on local storage
  */
 const useLocalStorage = (localStorageKey, defaultValue) => {
+  if (!isClient || !isAPISupported('localStorage')) {
+    // eslint-disable-next-line no-console
+    console.warn(errorMessage);
+    return [null, () => undefined];
+  }
+
   const [value, setValue] = useState(
     safelyParseJson(
       window.localStorage.getItem(localStorageKey)

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -13,7 +13,7 @@ const useLocalStorage = (localStorageKey, defaultValue) => {
   if (!isClient || !isAPISupported('localStorage')) {
     // eslint-disable-next-line no-console
     console.warn(errorMessage);
-    return [null, () => undefined];
+    return [JSON.stringify(defaultValue), () => undefined];
   }
 
   const [value, setValue] = useState(

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -3,16 +3,25 @@ import safelyParseJson from './utils/safelyParseJson';
 import isClient from './utils/isClient';
 import isAPISupported from './utils/isAPISupported';
 
-const errorMessage = 'localStorage is not supported, this could happen both because window.localStorage is not '
-    + 'supported by your current browser or you\'re using the useLocalStorage hook whilst server side rendering.';
+const errorMessageSSR = 'localStorage is not supported, this could happen because you\'re using the useLocalStorage'
+    + ' hook whilst server side rendering.';
+
+const errorMessageIsNotSupported = 'localStorage is not supported, this could happen because window.localStorage is '
+    + 'not supported by your current browser';
 
 /**
  * Save a value on local storage
  */
 const useLocalStorage = (localStorageKey, defaultValue) => {
-  if (!isClient || !isAPISupported('localStorage')) {
+  if (!isClient) {
     // eslint-disable-next-line no-console
-    console.warn(errorMessage);
+    console.warn(errorMessageSSR);
+    return [JSON.stringify(defaultValue), () => undefined];
+  }
+
+  if (!isAPISupported('localStorage')) {
+    // eslint-disable-next-line no-console
+    console.warn(errorMessageIsNotSupported);
     return [JSON.stringify(defaultValue), () => undefined];
   }
 

--- a/src/useLocalStorage.spec.js
+++ b/src/useLocalStorage.spec.js
@@ -59,7 +59,7 @@ describe('useLocalStorage', () => {
     const warnSpy = sinon.spy(console, 'warn');
     const { result } = renderHook(() => useLocalStorage('test-key'));
 
-    expect(result.current[0]).to.be.null;
+    expect(result.current[0]).to.be.undefined;
     expect(result.current[1].called).to.be.undefined;
     expect(warnSpy.called).to.be.true;
   });

--- a/src/useLocalStorage.spec.js
+++ b/src/useLocalStorage.spec.js
@@ -52,4 +52,15 @@ describe('useLocalStorage', () => {
 
     expect(container.querySelector('p').innerHTML).to.equal('200');
   });
+
+  it('should warn when the window.localStorage API is not supported', () => {
+    Reflect.deleteProperty(window, 'localStorage');
+
+    const warnSpy = sinon.spy(console, 'warn');
+    const { result } = renderHook(() => useLocalStorage('test-key'));
+
+    expect(result.current[0]).to.be.null;
+    expect(result.current[1].called).to.be.undefined;
+    expect(warnSpy.called).to.be.true;
+  });
 });

--- a/src/useLocalStorage.spec.js
+++ b/src/useLocalStorage.spec.js
@@ -54,7 +54,9 @@ describe('useLocalStorage', () => {
   });
 
   it('should warn when the window.localStorage API is not supported', () => {
-    Reflect.deleteProperty(window, 'localStorage');
+    const copyWindow = { ...window };
+    Reflect.deleteProperty(copyWindow, 'localStorage');
+    sinon.stub(global, 'window').value(copyWindow);
 
     const warnSpy = sinon.spy(console, 'warn');
     const { result } = renderHook(() => useLocalStorage('test-key'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add check to support window object or LocalStorage in the environment. If you use `useLocalStorage` hook with SSR app this causes the application to crash

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/beautifulinteractions/beautiful-react-hooks/issues/87

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves an issue where using hooks that use window fail SSR apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Couldn't add unit tests for this because when I delete window object all test to crush. But I have been creating test is that `localStorage` not in window object.