### PR TITLE
Update useDebouncedFn type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,9 +23,12 @@ type Cancelable = {
 }
 
 /**
- * useDebouncedFn
+ * Accepts a function and returns a new debounced yet memoized version of that same function that delays
+ * its invoking by the defined time.
+ *
+ * If `wait` is not defined, its default value will be 250ms.
  */
-export declare const useDebouncedFn: (fn: Function, wait?: number, options?: ThrottleOrDebounceOpts, dependencies?: DependencyList) => Cancelable;
+export declare const useDebouncedFn: <F extends Function>(fn: F, wait?: number, options?: Partial<ThrottleOrDebounceOpts>, dependencies?: DependencyList) => F & Cancelable;
 
 /**
  * useDidMount


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fixes #83 TypeScript: This expression is not callable. Type 'Cancelable' has no call signatures.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#83 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
