### PR TITLE
Improve types for `useLocalStorage` and `useSessionStorage`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,8 +16,8 @@ type EventListenerOptions = {
   passive: boolean,
 }
 
-type HandlerSetter = (...parameters: Array<any>) => unknown;
-
+type HandlerSetter <T = Array<any>> = (a: T) => void;
+                    
 type Cancelable = {
   cancel(): void;
   flush(): void;
@@ -223,12 +223,12 @@ export declare const useRequestAnimationFrame: (func: Function, options?: UseReq
 /**
  * useLocalStorage
  */
-export declare const useLocalStorage: (localStorageKey: string, defaultValue: any) => [any, HandlerSetter];
+export declare function useLocalStorage<T = any>(localStorageKey: string, defaultValue: T): [T, HandlerSetter<T>];
 
 /**
  * useSessionStorage
  */
-export declare const useSessionStorage: (localStorageKey: string, defaultValue: any) => [any, HandlerSetter];
+export declare function useSessionStorage<T = any>(localStorageKey: string, defaultValue: T): [T, HandlerSetter<T>];
 
 /**
  * useStorage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `useLocalStorage` and `useSessionStorage` hooks are now more strongly typed.

```
const defaultFlag: boolean = true;
const [myFlag, setFlag] = useLocalStorage('my-flag', defaultFlag);

// ...later 
setMyFlag('off') <-- Type mismatch, string is not equal to boolean
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No related issue, but happy to make one if requested 👍 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This helps TypeScript users from having to cast this value, and is more in line with how React's `useState` is typed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4524175/92850764-ab73d200-f3a1-11ea-89a3-e007ec52c0ff.png)
