### PR TITLE
fix: isDevelopment error for webpack v5

### DIFF
--- a/src/utils/isDevelopment.js
+++ b/src/utils/isDevelopment.js
@@ -1,3 +1,3 @@
-const isDevelopment = (process && process.env && (!process.env.NODE_ENV || process.env.NODE_ENV === 'development'));
+const isDevelopment = (typeof process !== 'undefined' && process.env && (!process.env.NODE_ENV || process.env.NODE_ENV === 'development'));
 
 export default isDevelopment;


### PR DESCRIPTION
This PR makes `isDevelopment` work when `process` is `undefined`.

## Description
Webpack 5 doesn't provide a mock of `process`, so the current implementaion causes an error `Uncaught ReferenceError: process is not defined`. This PR fixes the error.

## Related Issue
#164

## Motivation and Context
Close #164

## How Has This Been Tested?
I've confirm this PR fixes the error by editting `node_modules/beautiful-react-hooks/esm/utils/isDevelopment.js` directly. 
