### PR TITLE
[ci skip] :memo: fix comment and added right link to docs

### DIFF
--- a/docs/useDebouncedFn.md
+++ b/docs/useDebouncedFn.md
@@ -49,7 +49,7 @@ const DebouncedFnComponent = () => {
 
 ### Options
 
-Since `useDebouncedFn` uses [lodash.throttle](https://www.npmjs.com/package/lodash.throttle) 
+Since `useDebouncedFn` uses [lodash.debounce](https://www.npmjs.com/package/lodash.debounce);
 under the hood, you can possibly define few options to customise its behaviour.
 
 ```jsx harmony

--- a/src/useDebouncedFn.js
+++ b/src/useDebouncedFn.js
@@ -9,7 +9,7 @@ const defaultOptions = {
 /**
  * Accepts a function and returns a new debounced yet memoized version of that same function that delays
  * its invoking by the defined time.
- * If time is not defined, its default value will be 250ms.
+ * If time is not defined, its default value will be 100ms.
  */
 const useDebouncedFn = (fn, wait = 100, options = defaultOptions, dependencies) => {
   const debounced = debounce(fn, wait, options);


### PR DESCRIPTION
# UseDebounceFn Hook docs and comment fix.

## Description
<!--- Describe your changes in detail -->
Fixed comment in useDebounceFn.js file according to value of wait parameter.
Fixed link from lodash.throttle to lodash.debounce in useDebounceFn.md file.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related open issue: https://github.com/beautifulinteractions/beautiful-react-hooks/issues/178
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just fixing docs of that beautiful library.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
