### PR TITLE
Fix link to useGeolcationEvents in useGeolocation

### DIFF
--- a/docs/useGeolocation.md
+++ b/docs/useGeolocation.md
@@ -1,7 +1,7 @@
 # useGeolocation
 
 Returns an array where the first item is the geolocation state from [useGeolocationState](./useGeolocation.md) 
-and the second one is an object of handler setters from the [useGeolocationEvents](./useGeolocationEvents).
+and the second one is an object of handler setters from the [useGeolocationEvents](./useGeolocationEvents.md).
 
 It is intended as a shortcut to those hooks.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a small issue in useGeoLocation doc that redirects to a wrong address for `useGeolocationEvents`

## Description
The change will point to correct path of useGeolocationEvents doc in useGeoLocation doc.

## Motivation and Context
Faced it while going through docs for useGeolocation.

## How Has This Been Tested?
I tested it with Github's markdown preview.
