### PR TITLE
Observe elementRef.current instead of elementRef in useResizeObserver

### DIFF
--- a/src/useResizeObserver.js
+++ b/src/useResizeObserver.js
@@ -46,7 +46,7 @@ const useResizeObserver = (elementRef, debounceTimeout = 100) => {
     if (isSupported && elementRef.current) {
       observerRef.current.observe(elementRef.current);
     }
-  }, [elementRef]);
+  }, [elementRef.current]);
 
   return DOMRect;
 };


### PR DESCRIPTION
Hi, I noticed a weird bug when ref.current value is mutated the useResizeObserver hook stops working and only returns zeros. This is caused by incorrect use of useEffect hook that's point to the whole ref object instead of the current field.

## Motivation and Context
It solves a problem where useResizeObserver stops working after the ref value is mutated. For example when the observed object is removed from DOM and then a new one is created in its place.