### PR TITLE
:bug: allow window to be undefined in api-support test

### DIFF
--- a/src/utils/isAPISupported.js
+++ b/src/utils/isAPISupported.js
@@ -1,6 +1,6 @@
 /**
  * Exports a boolean value reporting whether the given API is supported or not
  */
-const isApiSupported = (api) => (api in window);
+const isApiSupported = (api) => (typeof window !== 'undefined' ? api in window : false);
 
 export default isApiSupported;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When running SSR, any window-related hooks that call `isApiSupported` are failing because `window` is undefined.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
This came up before as #63 and was fixed in #64 - but it looks like it was then re-broken 2 days later in #66

## Motivation and Context
This allows a few key hooks (like useResizeObserver, etc) to exist in components that are rendered server-side, without crashing

## How Has This Been Tested?
I ran this locally

## Screenshots (if appropriate):
