### PR TITLE
Cancel debounced callback + disconnect all observers

### DIFF
--- a/src/useResizeObserver.js
+++ b/src/useResizeObserver.js
@@ -32,13 +32,14 @@ const useResizeObserver = (elementRef, debounceTimeout = 100) => {
       }, debounceTimeout);
 
       observerRef.current = new ResizeObserver(fn);
+
+      return () => {
+        fn.cancel();
+        observerRef.current.disconnect();
+      };
     }
 
-    return () => {
-      if (isSupported && observerRef.current && elementRef.current) {
-        observerRef.current.unobserve(elementRef.current);
-      }
-    };
+    return () => {};
   }, []);
 
   // observes on the provided element ref


### PR DESCRIPTION
## Description
* Dangling debounced callbacks are now canceled and don't throw "Can't perform a React state update on an unmounted component." error.
* ResizeObserver uses disconnect instead of unsubscribe. Before that, we could observe multiple elements but only unsubscribe from the last one when the component unmounts (potential memory leak).

## Related Issue
Fixes https://github.com/beautifulinteractions/beautiful-react-hooks/issues/229