### PR TITLE
Use viewport spy to disconnect early

### DIFF
--- a/src/useViewportSpy.js
+++ b/src/useViewportSpy.js
@@ -15,7 +15,7 @@ const errorMessage = 'IntersectionObserver is not supported, this could happen b
  * Uses the IntersectionObserverMock API to tell whether the given DOM Element (from useRef) is visible within the
  * viewport.
  */
-const useViewportSpy = (elementRef, options = defaultOptions) => {
+const useViewportSpy = (elementRef, options = defaultOptions, unsubscribeEarly= false) => {
   if (!isClient || !isApiSupported('IntersectionObserver')) {
     // eslint-disable-next-line no-console
     console.warn(errorMessage);
@@ -33,7 +33,7 @@ const useViewportSpy = (elementRef, options = defaultOptions) => {
           setIsVisible(nextValue);
         }
       }), options);
-      if (isVisibleRef.current) {
+      if (isVisibleRef.current && unsubscribeEarly) {
         observer.disconnect();
         disconnected.current = true;
       }

--- a/src/useViewportSpy.js
+++ b/src/useViewportSpy.js
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState, useRef } from 'react';
 import isClient from './utils/isClient';
 import isApiSupported from './utils/isAPISupported';
 
@@ -8,8 +8,8 @@ const defaultOptions = {
   threshold: 0,
 };
 const errorMessage = 'IntersectionObserver is not supported, this could happen both because'
-  + ' window.IntersectionObserver is not supported by'
-  + ' your current browser or you\'re using the useViewportSpy hook whilst server side rendering.';
+    + ' window.IntersectionObserver is not supported by'
+    + ' your current browser or you\'re using the useViewportSpy hook whilst server side rendering.';
 
 /**
  * Uses the IntersectionObserverMock API to tell whether the given DOM Element (from useRef) is visible within the
@@ -21,23 +21,33 @@ const useViewportSpy = (elementRef, options = defaultOptions) => {
     console.warn(errorMessage);
     return null;
   }
-
+  const isVisibleRef = useRef(false);
+  const disconnected = useRef(false);
   const [isVisible, setIsVisible] = useState();
 
   useLayoutEffect(() => {
-    const observer = new window.IntersectionObserver((entries) => entries.forEach((item) => {
-      const nextValue = item.isIntersecting;
-      setIsVisible(nextValue);
-    }), options);
+    if (!disconnected.current) {
+      const observer = new window.IntersectionObserver((entries) => entries.forEach((item) => {
+        const nextValue = item.isIntersecting;
+        if (nextValue && !isVisibleRef.current) {
+          setIsVisible(nextValue);
+        }
+      }), options);
+      if (isVisibleRef.current) {
+        observer.disconnect();
+        disconnected.current = true;
+      }
+      observer.observe(elementRef.current);
 
-    observer.observe(elementRef.current);
-
-    return () => {
-      observer.disconnect(elementRef.current);
-    };
+      return () => {
+        observer.disconnect(elementRef.current);
+      };
+    }
   }, [elementRef]);
-
-  return isVisible;
+  if (!isVisibleRef.current && isVisible) {
+    isVisibleRef.current = isVisible;
+  }
+  return isVisibleRef.current;
 };
 
 export default useViewportSpy;


### PR DESCRIPTION
## Motivation and Context
When the contents doesn't appear in the corresponding viewport anymore or once the contents have been seen by the user, the hook need to disconnect, otherwise, it will perform redundant rendering via state update on intersectionObserver.
fixes #234