### PR TITLE
Using addEventListener instead of addListener that is deprecated

### DIFF
--- a/src/useMediaQuery.js
+++ b/src/useMediaQuery.js
@@ -26,11 +26,11 @@ const useMediaQuery = (mediaQuery) => {
     const mediaQueryList = window.matchMedia(mediaQuery);
     const documentChangeHandler = () => setIsVerified(!!mediaQueryList.matches);
 
-    mediaQueryList.addListener(documentChangeHandler);
+    mediaQueryList.addEventListener("change", documentChangeHandler);
 
     documentChangeHandler();
     return () => {
-      mediaQueryList.removeListener(documentChangeHandler);
+      mediaQueryList.removeEventListener("change", documentChangeHandler);
     };
   }, [mediaQuery]);
 


### PR DESCRIPTION
MediaQueryList.addListener() is no longer recommended.
See https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
