### PR TITLE
fix: the Global events example in useMouse.md

### DIFF
--- a/docs/useMouse.md
+++ b/docs/useMouse.md
@@ -48,23 +48,26 @@ const MouseReporter = () => {
 Avoid providing any argument to `useMouse`
 
 ```jsx harmony
-import { useRef, useState } from 'react';
-import { useMouse } from 'beautiful-react-hooks'; 
+import { useState } from 'react';
+import { useMouse } from 'beautiful-react-hooks';
 
 const MouseReporter = () => {
-  const ref = useRef();
-  const [ mouseIsOver, setMouseHover] = useState(false);
-  const [position, { onMouseEnter, onMouseLeave }] = useMouse(ref); 
-  
-  onMouseEnter(() => setMouseHover(true));
-  onMouseLeave(() => setMouseHover(false));
-  
+  const [showCoords, setShowCoords] = useState(false);
+  const [position, { onMouseDown, onMouseUp }] = useMouse();
+
+  onMouseDown(() => setShowCoords(true));
+  onMouseUp(() => setShowCoords(false));
+
   return (
     <DisplayDemo>
-     <div ref={ref} style={{background: mouseIsOver ? '#FF4365' : 'white'}}>
-       The current mouse coordinates are:
-       <p>{position.clientX}, {position.clientY}</p>
-     </div>
+      <div>
+        The current mouse coordinates are:
+        {showCoords && (
+          <p>
+            {position.clientX}, {position.clientY}
+          </p>
+        )}
+      </div>
     </DisplayDemo>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In  the global events example,  it is correct to `Avoid providing any argument to useMouse`. 
This fix referenced [useTouch's Global events example](https://beautifulinteractions.github.io/beautiful-react-hooks/#/useTouch).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I confirmed  that this example's code in [Live demo's VIEW CODE](https://beautifulinteractions.github.io/beautiful-react-hooks/#/useMouse) works.


## Screenshots (if appropriate):
